### PR TITLE
Fix resolving zone index to pod_node_label_selector in Azure

### DIFF
--- a/chaosgarden/garden/actions.py
+++ b/chaosgarden/garden/actions.py
@@ -313,6 +313,17 @@ def resolve_zones(spec: Dict) -> Set:
         zones |= set(worker.zones)
     return zones
 
+def resolve_pod_zones(spec: Dict) -> Set:
+    if spec.provider.type == 'azure':
+        zones = set()
+        for worker in spec.provider.workers:
+            for zone in worker.zones:
+                zones.add(f'{spec.region}-{zone}')
+        return zones
+    else:
+        return resolve_zones(spec)
+
+
 def resolve_zone(zone: Union[int, str], zones: Set) -> str:
     zones = sorted(zones)
     zones_as_string = ', '.join(zones)
@@ -343,7 +354,7 @@ def resolve_pod_simulation(target, zone, ignore_daemon_sets, pod_node_label_sele
             # zone cannot be resolved/validated, so we do not touch it
     else:
         kubeconfig = get_kubeconfig(garden_cluster = garden, project_namespace = project.spec.namespace, shoot_name = shoot.metadata.name)
-        zone       = resolve_zone(zone, resolve_zones(shoot.spec))
+        zone       = resolve_zone(zone, resolve_pod_zones(shoot.spec))
 
     # update selectors
     if zone:


### PR DESCRIPTION
**What this PR does / why we need it**:

For Azure, the zone names provided by `resolve_zones()` function is applicable for cloud provider simulations, however MCM for Azure creates `topology.kubernetes.io/zone` labels with values where the zone name is prepended with the region, e.g. `topology.kubernetes.io/zone=westeurope-2`.

This PR introduces the `resolve_pod_zones()` function to be used in `resolve_pod_simulation()`. The `resolve_pod_zones()` function calls `resolve_zones()` for all cases except when the provider is Azure, where it compiles the list of zones using `spec.provider.workers[*].zones[*]` by prepending the `{spec.region}-` to the zone names.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|developer
-->
```bugfix
Fix resolving the run_general_pod_failure_simulation zone attribute with Azure shoots.
```
