### PR TITLE
Add support for shared VPC network outage simulations (on AWS and GCP)

### DIFF
--- a/docs/aws/readme.md
+++ b/docs/aws/readme.md
@@ -39,7 +39,7 @@ Module: [`chaosgarden.aws.actions`](/chaosgarden/aws/actions.py)
 
 ### Cloud Provider Filters
 
-Please consult your cloud provider documentation for the exact filter syntax (not interpreted by `chaosgarden`).
+Please consult your cloud provider documentation for the exact filter syntax (not interpreted by `chaosgarden`). The subnets filter, if provided, will be amended with the VPC and the zone, so do not add these conditions to it.
 
 ### Configuration
 


### PR DESCRIPTION
Allow to run network outage simulations against Gardener shoot clusters that use a shared VPC (on AWS and GCP).

Fixes also https://github.com/gardener/chaos-engineering/issues/12.