### PR TITLE
Replace `secretBinding` with `credentialBinding`

### DIFF
--- a/chaosgarden/garden/actions.py
+++ b/chaosgarden/garden/actions.py
@@ -385,7 +385,7 @@ def resolve_cloud_provider_simulation(zone, configuration, secrets) -> Tuple[Cal
     if 'secretBindingName' in shoot.spec:
         binding     = Box(garden.client(API.CustomResources).get_namespaced_custom_object(name = shoot.spec.secretBindingName, namespace = project.spec.namespace, group = 'core.gardener.cloud', version = 'v1beta1', plural = 'secretbindings'))
     elif 'credentialsBindingName' in shoot.spec:
-        binding     = Box(garden.client(API.CustomResources).get_namespaced_custom_object(name = shoot.spec.credentialsBindingName, namespace = project.spec.namespace, group = 'core.gardener.cloud', version = 'v1beta1', plural = 'credentialsbindings'))
+        binding     = Box(garden.client(API.CustomResources).get_namespaced_custom_object(name = shoot.spec.credentialsBindingName, namespace = project.spec.namespace, group = 'security.gardener.cloud', version = 'v1alpha1', plural = 'credentialsbindings'))
     else:
         raise RuntimeError("Neither credentialsBindingName nor secretBindingName is present in shoot.spec")
     

--- a/chaosgarden/garden/actions.py
+++ b/chaosgarden/garden/actions.py
@@ -382,12 +382,12 @@ def resolve_cloud_provider_simulation(zone, configuration, secrets) -> Tuple[Cal
     project         = Box(garden.client(API.CustomResources).get_cluster_custom_object(name = configuration.garden_project, group = 'core.gardener.cloud', version = 'v1beta1', plural = 'projects'))
     shoot           = Box(garden.client(API.CustomResources).get_namespaced_custom_object(name = configuration.garden_shoot, namespace = project.spec.namespace, group = 'core.gardener.cloud', version = 'v1beta1', plural = 'shoots'))
 
-    try:
-    # Try to get the secretBinding first
-    binding         = Box(garden.client(API.CustomResources).get_namespaced_custom_object(name = shoot.spec.secretBindingName, namespace = project.spec.namespace,group = 'core.gardener.cloud', version = 'v1beta1', plural = 'secretbindings'))
-    except:
-    # If secretBinding is not found, try to get the credentialsBinding
-    binding         = Box(garden.client(API.CustomResources).get_namespaced_custom_object(name = shoot.spec.credentialsBindingName, namespace = project.spec.namespace, group = 'core.gardener.cloud', version = 'v1beta1', plural = 'credentialsbindings'))
+    if 'secretBindingName' in shoot.spec:
+        binding     = Box(garden.client(API.CustomResources).get_namespaced_custom_object(name = shoot.spec.secretBindingName, namespace = project.spec.namespace,group = 'core.gardener.cloud', version = 'v1beta1', plural = 'secretbindings'))
+    elif 'credentialsBindingName' in shoot.spec:
+        binding     = Box(garden.client(API.CustomResources).get_namespaced_custom_object(name = shoot.spec.credentialsBindingName, namespace = project.spec.namespace, group = 'core.gardener.cloud', version = 'v1beta1', plural = 'credentialsbindings'))
+    else:
+        raise RuntimeError("Neither credentialsBindingName nor secretBindingName is present in shoot.spec")
     
     credentials     = Box(garden.client(API.CoreV1).read_namespaced_secret(name = binding.secretRef.name, namespace = binding.secretRef.namespace).data)
     cloud_profile   = Box(garden.client(API.CustomResources).get_cluster_custom_object(name = shoot.spec.cloudProfileName, group = 'core.gardener.cloud', version = 'v1beta1', plural = 'cloudprofiles'))

--- a/chaosgarden/garden/actions.py
+++ b/chaosgarden/garden/actions.py
@@ -390,7 +390,6 @@ def resolve_cloud_provider_simulation(zone, configuration, secrets) -> Tuple[Cal
         credentials = Box(garden.client(API.CoreV1).read_namespaced_secret(name = binding.credentialsRef.name, namespace = binding.credentialsRef.namespace).data)    
     else:
         raise RuntimeError("Neither credentialsBindingName nor secretBindingName is present in shoot.spec")
-    
 
     cloud_profile   = Box(garden.client(API.CustomResources).get_cluster_custom_object(name = shoot.spec.cloudProfileName, group = 'core.gardener.cloud', version = 'v1beta1', plural = 'cloudprofiles'))
 

--- a/chaosgarden/garden/actions.py
+++ b/chaosgarden/garden/actions.py
@@ -384,12 +384,14 @@ def resolve_cloud_provider_simulation(zone, configuration, secrets) -> Tuple[Cal
 
     if 'secretBindingName' in shoot.spec:
         binding     = Box(garden.client(API.CustomResources).get_namespaced_custom_object(name = shoot.spec.secretBindingName, namespace = project.spec.namespace, group = 'core.gardener.cloud', version = 'v1beta1', plural = 'secretbindings'))
+        credentials = Box(garden.client(API.CoreV1).read_namespaced_secret(name = binding.secretRef.name, namespace = binding.secretRef.namespace).data)        
     elif 'credentialsBindingName' in shoot.spec:
         binding     = Box(garden.client(API.CustomResources).get_namespaced_custom_object(name = shoot.spec.credentialsBindingName, namespace = project.spec.namespace, group = 'security.gardener.cloud', version = 'v1alpha1', plural = 'credentialsbindings'))
+        credentials = Box(garden.client(API.CoreV1).read_namespaced_secret(name = binding.credentialsRef.name, namespace = binding.credentialsRef.namespace).data)    
     else:
         raise RuntimeError("Neither credentialsBindingName nor secretBindingName is present in shoot.spec")
     
-    credentials     = Box(garden.client(API.CoreV1).read_namespaced_secret(name = binding.secretRef.name, namespace = binding.secretRef.namespace).data)
+
     cloud_profile   = Box(garden.client(API.CustomResources).get_cluster_custom_object(name = shoot.spec.cloudProfileName, group = 'core.gardener.cloud', version = 'v1beta1', plural = 'cloudprofiles'))
 
     # handle different cloud providers

--- a/chaosgarden/garden/actions.py
+++ b/chaosgarden/garden/actions.py
@@ -383,7 +383,7 @@ def resolve_cloud_provider_simulation(zone, configuration, secrets) -> Tuple[Cal
     shoot           = Box(garden.client(API.CustomResources).get_namespaced_custom_object(name = configuration.garden_shoot, namespace = project.spec.namespace, group = 'core.gardener.cloud', version = 'v1beta1', plural = 'shoots'))
 
     if 'secretBindingName' in shoot.spec:
-        binding     = Box(garden.client(API.CustomResources).get_namespaced_custom_object(name = shoot.spec.secretBindingName, namespace = project.spec.namespace,group = 'core.gardener.cloud', version = 'v1beta1', plural = 'secretbindings'))
+        binding     = Box(garden.client(API.CustomResources).get_namespaced_custom_object(name = shoot.spec.secretBindingName, namespace = project.spec.namespace, group = 'core.gardener.cloud', version = 'v1beta1', plural = 'secretbindings'))
     elif 'credentialsBindingName' in shoot.spec:
         binding     = Box(garden.client(API.CustomResources).get_namespaced_custom_object(name = shoot.spec.credentialsBindingName, namespace = project.spec.namespace, group = 'core.gardener.cloud', version = 'v1beta1', plural = 'credentialsbindings'))
     else:

--- a/chaosgarden/garden/actions.py
+++ b/chaosgarden/garden/actions.py
@@ -389,7 +389,7 @@ def resolve_cloud_provider_simulation(zone, configuration, secrets) -> Tuple[Cal
     # If secretBinding is not found, try to get the credentialsBinding
     binding         = Box(garden.client(API.CustomResources).get_namespaced_custom_object(name = shoot.spec.credentialsBindingName, namespace = project.spec.namespace, group = 'core.gardener.cloud', version = 'v1beta1', plural = 'credentialsbindings'))
     
-    credentials = Box(garden.client(API.CoreV1).read_namespaced_secret(name = binding.secretRef.name, namespace = binding.secretRef.namespace).data)
+    credentials     = Box(garden.client(API.CoreV1).read_namespaced_secret(name = binding.secretRef.name, namespace = binding.secretRef.namespace).data)
     cloud_profile   = Box(garden.client(API.CustomResources).get_cluster_custom_object(name = shoot.spec.cloudProfileName, group = 'core.gardener.cloud', version = 'v1beta1', plural = 'cloudprofiles'))
 
     # handle different cloud providers

--- a/chaosgarden/garden/actions.py
+++ b/chaosgarden/garden/actions.py
@@ -381,8 +381,15 @@ def resolve_cloud_provider_simulation(zone, configuration, secrets) -> Tuple[Cal
     garden          = Cluster('garden', authenticator)
     project         = Box(garden.client(API.CustomResources).get_cluster_custom_object(name = configuration.garden_project, group = 'core.gardener.cloud', version = 'v1beta1', plural = 'projects'))
     shoot           = Box(garden.client(API.CustomResources).get_namespaced_custom_object(name = configuration.garden_shoot, namespace = project.spec.namespace, group = 'core.gardener.cloud', version = 'v1beta1', plural = 'shoots'))
-    credential_binding  = Box(garden.client(API.CustomResources).get_namespaced_custom_object(name = shoot.spec.credentialsBindingName, namespace = project.spec.namespace, group = 'core.gardener.cloud', version = 'v1beta1', plural = 'credentialbindings'))
-    credentials     = Box(garden.client(API.CoreV1).read_namespaced_secret(name = credential_binding.secretRef.name, namespace = credential_binding.secretRef.namespace).data)
+
+    try:
+    # Try to get the secretBinding first
+    binding         = Box(garden.client(API.CustomResources).get_namespaced_custom_object(name = shoot.spec.secretBindingName, namespace = project.spec.namespace,group = 'core.gardener.cloud', version = 'v1beta1', plural = 'secretbindings'))
+    except:
+    # If secretBinding is not found, try to get the credentialsBinding
+    binding         = Box(garden.client(API.CustomResources).get_namespaced_custom_object(name = shoot.spec.credentialsBindingName, namespace = project.spec.namespace, group = 'core.gardener.cloud', version = 'v1beta1', plural = 'credentialsbindings'))
+    
+    credentials = Box(garden.client(API.CoreV1).read_namespaced_secret(name = binding.secretRef.name, namespace = binding.secretRef.namespace).data)
     cloud_profile   = Box(garden.client(API.CustomResources).get_cluster_custom_object(name = shoot.spec.cloudProfileName, group = 'core.gardener.cloud', version = 'v1beta1', plural = 'cloudprofiles'))
 
     # handle different cloud providers

--- a/chaosgarden/garden/actions.py
+++ b/chaosgarden/garden/actions.py
@@ -381,8 +381,8 @@ def resolve_cloud_provider_simulation(zone, configuration, secrets) -> Tuple[Cal
     garden          = Cluster('garden', authenticator)
     project         = Box(garden.client(API.CustomResources).get_cluster_custom_object(name = configuration.garden_project, group = 'core.gardener.cloud', version = 'v1beta1', plural = 'projects'))
     shoot           = Box(garden.client(API.CustomResources).get_namespaced_custom_object(name = configuration.garden_shoot, namespace = project.spec.namespace, group = 'core.gardener.cloud', version = 'v1beta1', plural = 'shoots'))
-    secret_binding  = Box(garden.client(API.CustomResources).get_namespaced_custom_object(name = shoot.spec.secretBindingName, namespace = project.spec.namespace, group = 'core.gardener.cloud', version = 'v1beta1', plural = 'secretbindings'))
-    credentials     = Box(garden.client(API.CoreV1).read_namespaced_secret(name = secret_binding.secretRef.name, namespace = secret_binding.secretRef.namespace).data)
+    credential_binding  = Box(garden.client(API.CustomResources).get_namespaced_custom_object(name = shoot.spec.credentialsBindingName, namespace = project.spec.namespace, group = 'core.gardener.cloud', version = 'v1beta1', plural = 'credentialbindings'))
+    credentials     = Box(garden.client(API.CoreV1).read_namespaced_secret(name = credential_binding.secretRef.name, namespace = credential_binding.secretRef.namespace).data)
     cloud_profile   = Box(garden.client(API.CustomResources).get_cluster_custom_object(name = shoot.spec.cloudProfileName, group = 'core.gardener.cloud', version = 'v1beta1', plural = 'cloudprofiles'))
 
     # handle different cloud providers


### PR DESCRIPTION
**What this PR does / why we need it**:
Due to advances on the Gardener side, we need to update the chaos setup to the latest landscape configuration.

**Which issue(s) this PR fixes**:
Fixes recent run of the chaos tests 

```
    secret_binding  = Box(garden.client(API.CustomResources).get_namespaced_custom_object(name = shoot.spec.secretBindingName, namespace = project.spec.namespace, group = 'core.gardener.cloud', version = 'v1beta1', plural = 'secretbindings'))
                                                                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "box/box.py", line 649, in box.box.Box.__getattr__
box.exceptions.BoxKeyError: "'Box' object has no attribute 'secretBindingName'"
```

**Special notes for your reviewer**:
/invite @vlerenc 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|developer
-->
```feature user

```
