### PR TITLE
Replace cli.py with gardener-ci

### DIFF
--- a/.ci/release_to_pypi
+++ b/.ci/release_to_pypi
@@ -13,7 +13,7 @@ pip3 install --upgrade pip wheel setuptools twine
 python3 "${repo_dir}/setup.py" sdist bdist_wheel
 
 # retrieve PyPI credentials
-model_element_cmd="cli.py config model_element --cfg-type pypi --cfg-name gardener"
+model_element_cmd="gardener-ci config model_element --cfg-type pypi --cfg-name gardener"
 username="$(${model_element_cmd} --key credentials.username)"
 passwd="$(${model_element_cmd} --key credentials.passwd)"
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The cicd toolkit changed and replaces `cli.py` with `gardener-ci`.

**Which issue(s) this PR fixes**:
Fixes failing release job with error

`git-gardener.chaos-engineering-main/.ci/release_to_pypi: line 17: cli.py: command not found`

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|developer
-->
```feature user
NONE
```
